### PR TITLE
Don't gate ^plsno

### DIFF
--- a/donations/donations.py
+++ b/donations/donations.py
@@ -158,7 +158,6 @@ class Donations(commands.Cog):
         self.settings.addInsultsEnabled(user_id)
         await ctx.send(ctx.author.mention + ' ' 'Oh, I will.\n' + random.choice(self.insults_list))
 
-    @is_donor()
     @commands.command()
     async def plsno(self, ctx):
         """I am merciful."""


### PR DESCRIPTION
Non-donors can't make the bot stop insulting them.  This can happen if you only have Patreon status and not donor and you lose it.