### PR TITLE
remindme show tz in DM, toggle subcommand for settimezone

### DIFF
--- a/timecog/timecog.py
+++ b/timecog/timecog.py
@@ -197,7 +197,7 @@ class TimeCog(commands.Cog):
         async with self.config.user(ctx.author).reminders() as rms:
             rms.append((rmtime.timestamp(), input, -1, 0))
 
-        response = "I will tell you " + format_rm_time(ctx, rmtime, input, user_timezone, user_show_tz)
+        response = "I will tell you " + format_rm_time(ctx.channel, rmtime, input, user_timezone, user_show_tz)
         if not user_tz_str:
             response += '. Configure your personal timezone with `{0.clean_prefix}settimezone` for accurate times.'.format(
                 ctx)
@@ -214,7 +214,7 @@ class TimeCog(commands.Cog):
         async with self.config.user(ctx.author).reminders() as rms:
             rms.append((rmtime.timestamp(), input, -1, ctx.channel.id))
 
-        response = "In this channel, I will tell you " + format_rm_time(ctx, rmtime, input, user_timezone, user_show_tz)
+        response = "In this channel, I will tell you " + format_rm_time(ctx.channel, rmtime, input, user_timezone, user_show_tz)
         if not user_tz_str:
             response += '. Configure your personal timezone with `{0.clean_prefix}settimezone` for accurate times.'.format(
                 ctx)
@@ -248,7 +248,7 @@ class TimeCog(commands.Cog):
         user_show_tz = await self.config.user(ctx.author).show_tz()
         m = await ctx.send("I will tell you {} and every {} seconds after that."
                            "".format(format_rm_time(
-            ctx,
+            ctx.channel,
             datetime.utcnow() + tin2tdelta(tinstart),
             input,
             tzstr_to_tz(await self.config.user(ctx.author).tz() or 'UTC'),
@@ -268,7 +268,7 @@ class TimeCog(commands.Cog):
         for c, rm in enumerate(rlist):
             timestamp = rm[0]
             input = rm[1]
-            ftime = format_rm_time(ctx, datetime.fromtimestamp(float(timestamp)), input, tz, user_show_tz)
+            ftime = format_rm_time(ctx.channel, datetime.fromtimestamp(float(timestamp)), input, tz, user_show_tz)
             if len(rm) > 2 and rm[2] != -1:
                 ftime += f" (every {rm[2]} seconds)"
             if len(rm) > 3 and rm[3] != 0:
@@ -776,8 +776,8 @@ def ydhm(seconds):
     return " ".join(ydhm) or "<1 minute"
 
 
-def format_rm_time(ctx, rmtime, input, D_TZ, show_tz):
-    if not isinstance(ctx.channel, discord.DMChannel) and not show_tz:
+def format_rm_time(ctx_channel, rmtime, input, D_TZ, show_tz):
+    if not isinstance(ctx_channel, discord.DMChannel) and not show_tz:
         return "'{}' ({} from now)".format(
             input,
             ydhm((rmtime - datetime.utcnow()).total_seconds() + 2)

--- a/timecog/timecog.py
+++ b/timecog/timecog.py
@@ -197,7 +197,7 @@ class TimeCog(commands.Cog):
         async with self.config.user(ctx.author).reminders() as rms:
             rms.append((rmtime.timestamp(), input, -1, 0))
 
-        response = "I will tell you " + format_rm_time(rmtime, input, user_timezone, user_show_tz)
+        response = "I will tell you " + format_rm_time(ctx, rmtime, input, user_timezone, user_show_tz)
         if not user_tz_str:
             response += '. Configure your personal timezone with `{0.clean_prefix}settimezone` for accurate times.'.format(
                 ctx)
@@ -214,7 +214,7 @@ class TimeCog(commands.Cog):
         async with self.config.user(ctx.author).reminders() as rms:
             rms.append((rmtime.timestamp(), input, -1, ctx.channel.id))
 
-        response = "In this channel, I will tell you " + format_rm_time(rmtime, input, user_timezone, user_show_tz)
+        response = "In this channel, I will tell you " + format_rm_time(ctx, rmtime, input, user_timezone, user_show_tz)
         if not user_tz_str:
             response += '. Configure your personal timezone with `{0.clean_prefix}settimezone` for accurate times.'.format(
                 ctx)
@@ -248,6 +248,7 @@ class TimeCog(commands.Cog):
         user_show_tz = await self.config.user(ctx.author).show_tz()
         m = await ctx.send("I will tell you {} and every {} seconds after that."
                            "".format(format_rm_time(
+            ctx,
             datetime.utcnow() + tin2tdelta(tinstart),
             input,
             tzstr_to_tz(await self.config.user(ctx.author).tz() or 'UTC'),
@@ -267,7 +268,7 @@ class TimeCog(commands.Cog):
         for c, rm in enumerate(rlist):
             timestamp = rm[0]
             input = rm[1]
-            ftime = format_rm_time(datetime.fromtimestamp(float(timestamp)), input, tz, user_show_tz)
+            ftime = format_rm_time(ctx, datetime.fromtimestamp(float(timestamp)), input, tz, user_show_tz)
             if len(rm) > 2 and rm[2] != -1:
                 ftime += f" (every {rm[2]} seconds)"
             if len(rm) > 3 and rm[3] != 0:
@@ -295,13 +296,18 @@ class TimeCog(commands.Cog):
     @remindme.command()
     async def toggletzprivate(self, ctx):
         """Hide/show your time zone in reminders"""
+        await self._toggletzprivate(ctx)
+
+    async def _toggletzprivate(self, ctx):
         if await self.config.user(ctx.author).show_tz():
             await self.config.user(ctx.author).show_tz.set(False)
-            await ctx.send("Ok, your time zone is now set to **private**. I will **hide** your time zone when I confirm or list your reminders.")
+            await ctx.send(
+                "Ok, your time zone is now set to **private**. I will **hide** your time zone when I confirm or list your reminders in a server.")
             return
         else:
             await self.config.user(ctx.author).show_tz.set(True)
-            await ctx.send("Ok, your time zone is now set to **public**. I will **show** your time zone when I confirm or list your reminders.")
+            await ctx.send(
+                "Ok, your time zone is now set to **public**. I will **show** your time zone when I confirm or list your reminders in a server.")
             return
 
     @commands.group(invoke_without_command=True)
@@ -495,7 +501,7 @@ class TimeCog(commands.Cog):
         for page in pagify(o):
             await ctx.send(box(page))
 
-    @commands.command(aliases=['settz'])
+    @commands.group(aliases=['settz'], invoke_without_command=True)
     async def settimezone(self, ctx, tzstr):
         """Set your timezone."""
         try:
@@ -504,6 +510,11 @@ class TimeCog(commands.Cog):
             await ctx.send(inline("Set personal timezone to {} ({})".format(str(v), get_tz_name(v))))
         except IOError as e:
             await ctx.send(inline("Invalid tzstr: " + tzstr))
+            
+    @settimezone.command()
+    async def toggleprivate(self, ctx):
+        """Hide/show your time zone in reminders"""
+        await self._toggletzprivate(ctx)
 
     async def reminderloop(self):
         try:
@@ -765,8 +776,8 @@ def ydhm(seconds):
     return " ".join(ydhm) or "<1 minute"
 
 
-def format_rm_time(rmtime, input, D_TZ, show_tz):
-    if not show_tz:
+def format_rm_time(ctx, rmtime, input, D_TZ, show_tz):
+    if not isinstance(ctx.channel, discord.DMChannel) and not show_tz:
         return "'{}' ({} from now)".format(
             input,
             ydhm((rmtime - datetime.utcnow()).total_seconds() + 2)


### PR DESCRIPTION
Time zone is now always shown in DM for remindme, and the `toggleprivate` subcommand is added to `^settimezone` with the same exact functionality as `remindme toggletzprivate`